### PR TITLE
IRIS PDR-2: Additional change proposal for TCS - IRIS ICD

### DIFF
--- a/imager/adc-assembly/subscribe-model.conf
+++ b/imager/adc-assembly/subscribe-model.conf
@@ -12,16 +12,6 @@ To determine the angle of two rotary stages.
 """
      }
      {
-       subsystem = TCS
-       component = cmIRIS
-       name = parallacticAngle
-       usage = """
-To determine the angle of two rotary stages.
-
-The parallactic angle is the same as the orientation of the elevation axis in FCRS<sub>IRIS-ROT</sub>, which rotates with respect to NFIRAOS. The rate of this event must be fast enough to keep the position accuracy when tracking an object that transits 1 degree of the zenith angle.
-"""
-     } 
-     {
         subsystem = TCS
         component = cmIRIS
         name = odgwPosDemands

--- a/imager/adc-assembly/subscribe-model.conf
+++ b/imager/adc-assembly/subscribe-model.conf
@@ -2,16 +2,25 @@ subsystem = IRIS
 component = sci-adc-assembly
 
 subscribe {
-  description = """
-IRIS Science Path ADC Assembly subscribes to some events from TCS to determine the angle of two rotary stages. Orientation of the elevation axis (target orientation of ADC) is given in FCRS<sub>IRIS-ROT</sub> which rotates with respect to NFIRAOS. Thus, this assembly does not have to monitor instrument rotator angle.
-"""
-
   events = [
     {
        subsystem = TCS
        component = cmIRIS
        name = imgAtmDispersion
+       usage = """
+To determine the angle of two rotary stages.
+"""
      }
+     {
+       subsystem = TCS
+       component = cmIRIS
+       name = parallacticAngle
+       usage = """
+To determine the angle of two rotary stages.
+
+The parallactic angle is the same as the orientation of the elevation axis in FCRS<sub>IRIS-ROT</sub>, which rotates with respect to NFIRAOS. The rate of this event must be fast enough to keep the position accuracy when tracking an object that transits 1 degree of the zenith angle.
+"""
+     } 
      {
         subsystem = TCS
         component = cmIRIS

--- a/imager/coldstop-assembly/subscribe-model.conf
+++ b/imager/coldstop-assembly/subscribe-model.conf
@@ -6,27 +6,9 @@ subscribe {
     {
       subsystem = TCS
       component = cmIRIS
-      name = parallacticAngle
-      usage = """
-This telemetry is used to determine the angle of the mask.
-
-__DISCUSSSION__: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will correct for the combination of parallactic angle and pupil rotation, meaning that the pupil orientation will vary. The cold stop will need the current parallactic angle to negate that angle caused by the instrument rotator, thus the mask is aligned with the telescope pupil.
-"""
-    }
-    {
-      subsystem = TCS
-      component = cmIRIS
       name = pupilRotation
       usage = """
-**TBD**: Currently, the necessity of subscribing the pupil rotation event is not clear. Maybe, it is not necessary, and will be removed.
-"""
-    }
-    {
-      subsystem = TCS
-      component = cmIRIS
-      name = instrumentRotatorAngle
-      usage = """
-This telemetry is used to calculate the desired position of X and Y linear stages to correct the misalignment between the instrument rotator axis and the optical axis of the instrument.
+This telemetry is used to determine the angle of the mask.
 """
     }
     {

--- a/imager/coldstop-assembly/subscribe-model.conf
+++ b/imager/coldstop-assembly/subscribe-model.conf
@@ -8,7 +8,15 @@ subscribe {
       component = cmIRIS
       name = pupilRotation
       usage = """
-This telemetry is used to determine the angle of the mask.
+This event will be used to determine the angle of the mask.
+"""
+    }
+    {
+      subsystem = IRIS
+      component = rotator-assembly
+      name      = current
+      usage     = """
+This event will be used to align the mask to compensate the misalignment between the instrument rotator axis and the optical axis.
 """
     }
     {

--- a/imager/coldstop-assembly/subscribe-model.conf
+++ b/imager/coldstop-assembly/subscribe-model.conf
@@ -6,13 +6,19 @@ subscribe {
     {
       subsystem = TCS
       component = cmIRIS
+      name = parallacticAngle
+      usage = """
+This telemetry is used to determine the angle of the mask.
+
+__DISCUSSSION__: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will correct for the combination of parallactic angle and pupil rotation, meaning that the pupil orientation will vary. The cold stop will need the current parallactic angle to negate that angle caused by the instrument rotator, thus the mask is aligned with the telescope pupil.
+"""
+    }
+    {
+      subsystem = TCS
+      component = cmIRIS
       name = pupilRotation
       usage = """
-This telemetry is used to calculate the parallactic angle by subtracting the instrument rotator angle by this value.
-
-It is finally translated to the position command to the rotary stage.
-
-__DISCUSSSION__: During LGS, NGS or seeing limited operations, the IRIS instrument rotator will correct for the combination of parallactic angle and pupil rotation, meaning that the pupil orientation will vary. The pupil mask rotators will need the current pupil rotation, likely after some linear transformation with constant coefficients, in order to keep a pupil mask aligned with the pupil image of the primary mirror.
+**TBD**: Currently, the necessity of subscribing the pupil rotation event is not clear. Maybe, it is not necessary, and will be removed.
 """
     }
     {
@@ -20,10 +26,7 @@ __DISCUSSSION__: During LGS, NGS or seeing limited operations, the IRIS instrume
       component = cmIRIS
       name = instrumentRotatorAngle
       usage = """
-This telemetry is used to calculate the parallactic angle by subtracting this value by the pupil rotation, and determine the angle of the rotary stage.
-
-This telemetry is also used to calculate the desired position of X and Y linear stages to correct the misalignment between the instrument rotator axis and the optical axis of the instrument.
-
+This telemetry is used to calculate the desired position of X and Y linear stages to correct the misalignment between the instrument rotator axis and the optical axis of the instrument.
 """
     }
     {

--- a/imager/pupilview-assembly/subscribe-model.conf
+++ b/imager/pupilview-assembly/subscribe-model.conf
@@ -37,7 +37,7 @@ __TBD__: Maybe instead of subscribing to this telemetry, this assembly should su
     {
        subsystem = IRIS
        component = rotator-assembly
-       name = currentInstrumentAngle
+       name = current
        usage = """
 Obtain the current angle of the instrument rotator to make the calibration table for the cold stop.
 """


### PR DESCRIPTION
This is a change proposal for TCS - IRIS ICD in addition to the pull request #35.

Cold Stop needs the parallactic angle, not the pupil rotation because the instrument rotator compensates the parallactic angle and the pupil rotation, and the cold stop inside the instrument just needs to negate the parallactic angle. This angle is expected to be published at 20 Hz, and 50 ms before the given parallactic angle becomes valid.

The orientation (the zenith direction in the focal plane) of Science ADC also subscribes the parallactic angle event stream because those two are the same. In addition, formally this orientation was published at 1 Hz as a part of imgAtmDispersion, but it might be too slow. The rotation caused by the parallactic angle is faster than the one caused by the atmospheric dispersion change, especially when tracking an object transiting 1 degree from the zenith.