### PR TITLE
changed/updated cryoenv assembly related telemetry items.

### DIFF
--- a/drs/drs-assembly/subscribe-model.conf
+++ b/drs/drs-assembly/subscribe-model.conf
@@ -460,18 +460,33 @@ Current position of the cold stop. Contains the following:
 
 {
   subsystem =  IRIS
-  component =  cryotemp-assembly
-  name =  sensor
+  component =  cryoenv-assembly
+  name =  IMG_TEMP[N]
   requiredRate =  4
   usage = """
-  Cryogenic temperature sensor information. Each sensor telemetry item includes an attribute <functionalgroup> which indicates if it is for the imager or IFS, and an attribute <sensorID> which identifies the sensor (A, B, C1-4, D1-4, with A and B typically used for inputs to a control loop). The attribute <location> gives the location of the sensor in the dewar, and the attribute <reading> gives the actual temperature reading at the sensor.
+  Cryogenic temperature sensor information for imager detectors and related temperature. Each sensor telemetry item includes an attribute <sensorID> which identifies the sensor (A, B, C1-4, D1-4, with A and B typically used for inputs to a control loop). The attribute <location> gives the location of the sensor in the dewar, and the attribute <reading> gives the actual temperature reading at the sensor.
 
 The following FITS keywords (for each functional group and sensor ID) will be constructed from these telemetry items:
 
 * Temperature of the imager detector. FITS=IMGTEMP
-* Temperature of the ifs detector. FITS=IFSTEMP
 * Temperature of the dewar reported by Imager temperature sensor <sensorID>. FITS=IMGTEMP<sensorID>
 * Description of the location of Imager temperature sensor <sensorID>. FITS=IMGNAME<sensorID>
+  
+  """
+  
+}
+
+{
+  subsystem =  IRIS
+  component =  cryoenv-assembly
+  name =  IFS_TEMP[N]
+  requiredRate =  4
+  usage = """
+  Cryogenic temperature sensor information for ifs detector and related temperature. Each sensor telemetry item includes an attribute <sensorID> which identifies the sensor (A, B, C1-4, D1-4, with A and B typically used for inputs to a control loop). The attribute <location> gives the location of the sensor in the dewar, and the attribute <reading> gives the actual temperature reading at the sensor.
+
+The following FITS keywords (for each functional group and sensor ID) will be constructed from these telemetry items:
+
+* Temperature of the ifs detector. FITS=IFSTEMP
 * Temperature of the dewar reported by IFS temperature sensor <sensorID>. FITS=IFSTEMP<sensorID>
 * Description of the location of IFS temperature sensor <sensorID>. FITS=IFSNAME<sensorID>
   
@@ -1230,8 +1245,8 @@ Information about current dither pattern position. Contains:
 
 {
   subsystem =  IRIS
-  component =  pressure-assembly
-  name =  pressure
+  component =  cryoenv-assembly
+  name =  PRESSURE
   requiredRate =  4
   usage = """
   Pressure gauge information. Each pressure telemetry item includes an attribute <gaugeNumber> which identifies the gauge. The attribute <gaugeDescription> gives a description of what the gauge is reading, and the attribute <value> gives the actual pressure reading of the gauge.


### PR DESCRIPTION
old telemetry "sensor" has been split to IMG_TEMP[N], and IFS_TEMP[N]
and pressure has been changed to "PRESSURE". Also all three telemetry
has been re-addressed as telemetry of cryoenv-assembly.