### PR TITLE
Assembly name change (cryotemp-assembly -> cryoenv-assembly) plus alpha

### DIFF
--- a/ifs/spectralres-assembly/command-model.conf
+++ b/ifs/spectralres-assembly/command-model.conf
@@ -287,6 +287,14 @@ __TODO__: Define the discrete positions
 
 Command type: submit
 """
+        requiredArgs = [position]
+        args = [
+            {
+                name = position
+                description = """Desired position of the lenslet mask."""
+                enum = [FULL_OPEN, HALF]
+            }
+        ]
     }
     {
         name = SHUTDOWN

--- a/ifs/spectralres-assembly/publish-model.conf
+++ b/ifs/spectralres-assembly/publish-model.conf
@@ -40,6 +40,11 @@ publish {
             description = "Indicates whether the motion is prohibited due to the interlock signal from Safety HCD."
             type = boolean
         }
+        {
+            name = selection
+            description = "the current grating selection"
+            enum = [4000-Z, 4000-Y, 4000-J, 4000-H, 4000-K, "4000-H+K", 8000-Z, 8000-Y, 8000-J, 8000-H, 8000-Kn1-3, 8000-Kn4-5, 8000-Kbb, 10000-Z, 10000-Y, 10000-J, 10000-H, 1000-K, Mirror, INTERMEDIATE, UNKNOWN]
+        }
       ]
     }
     {
@@ -127,6 +132,11 @@ publish {
             name = interlock
             description = "Indicates whether the motion is prohibited due to the interlock signal from Safety HCD."
             type = boolean
+        }
+        {
+            name = selection
+            description = "the current lenslet mask position"
+            enum = [FULL_OPEN, SERRATED_WIDE, FINE_MASK, FINE_MASK_CALIBRATION, INTERMEDIATE, UNKNOWN]
         }
       ]
     }
@@ -218,7 +228,7 @@ publish {
         }
         {
             name = selection
-            description = "the slicer mask position"
+            description = "the current slicer mask position"
             enum = [FULL_OPEN, INTERMEDIATE, HALF, UNKNOWN]
         }
       ]

--- a/ifs/spectralres-assembly/publish-model.conf
+++ b/ifs/spectralres-assembly/publish-model.conf
@@ -216,6 +216,11 @@ publish {
             description = "Indicates whether the motion is prohibited due to the interlock signal from Safety HCD."
             type = boolean
         }
+        {
+            name = selection
+            description = "the slicer mask position"
+            enum = [FULL_OPEN, INTERMEDIATE, HALF, UNKNOWN]
+        }
       ]
     }
     {

--- a/imager/adc-assembly/subscribe-model.conf
+++ b/imager/adc-assembly/subscribe-model.conf
@@ -27,8 +27,8 @@ __TBD__: check if the image offset depends on ODGW position.
   telemetry = [
     {
       subsystem = IRIS
-      component = cryotemp-assembly
-      name = sensor
+      component = cryoenv-assembly
+      name = "IMG_TEMP[N]"
       usage = """
 For ovearheating protection.
 """

--- a/imager/coldstop-assembly/subscribe-model.conf
+++ b/imager/coldstop-assembly/subscribe-model.conf
@@ -21,8 +21,8 @@ This event will be used to align the mask to compensate the misalignment between
     }
     {
       subsystem = IRIS
-      component = cryotemp-assembly
-      name = sensor
+      component = cryoenv-assembly
+      name = "IMG_TEMP[N]"
       usage = """
 For ovearheating protection.
 """

--- a/imager/filter-assembly/subscribe-model.conf
+++ b/imager/filter-assembly/subscribe-model.conf
@@ -5,8 +5,8 @@ subscribe {
   telemetry = [
     {
       subsystem = IRIS
-      component = cryotemp-assembly
-      name = sensor
+      component = cryoenv-assembly
+      name = "IMG_TEMP[N]"
       usage = """
 For ovearheating protection.
 """


### PR DESCRIPTION
To sync with recent Jiman's change for the new assembly "cryoenv-assembly" that integrates old "cryotemp-assembly" and other assemblies, I fixed the list of the telemetries subscribed by Imager assemblies. Some Imager assemblies monitor the temperature reading from cryoenv-assembly for overheating protection.

This pull request also includes the definition of the discrete position names of the IFS mechanisms.