### PR TITLE
Moved all telemetries to events.

### DIFF
--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -15,9 +15,9 @@ __TODO__: Add configuration of the image shift model.
      {
         name = odgwShift
         description = """
-        IRIS publishes the expected ADC image shifts of the (up to 4) IRIS ODGW position demands
+IRIS publishes the expected ADC image shifts of the (up to 4) IRIS ODGW position demands
 
-        *Discussion: The ADC will shift an image position in a manner that depends upon the current state of the ADC. The estimated image shift (inferred from optical models) is sent from IRIS to the TCS so that the TCS can adjust the IRIS ODGW position demands accordingly. The reference wavelength used to calculate the shift is tcs.cm.iris.imgCurAtmDispersion.referenceWavelength.*
+*Discussion: The ADC will shift an image position in a manner that depends upon the current state of the ADC. The estimated image shift (inferred from optical models) is sent from IRIS to the TCS so that the TCS can adjust the IRIS ODGW position demands accordingly. The reference wavelength used to calculate the shift is tcs.cm.iris.imgCurAtmDispersion.referenceWavelength.*
         """
         maxRate = 1
         archive = true

--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -192,11 +192,6 @@ This attribute turns to be true when the posiiton errors are withtin the prescri
         }      
       ]
     }
-
-
-  ]
-
-  telemetry = [
     {
       name = RETRACT_state
       description = "Standard assembly state as defiend in [Technical Document: Software Design Patterns for Device and Component Controllers (TMT.INS.TEC.16.079.REL01)](https://docushare.tmt.org/docushare/dsweb/Get/Document-57492/cc_design_patterns_REL01.pdf)."

--- a/imager/coldstop-assembly/publish-model.conf
+++ b/imager/coldstop-assembly/publish-model.conf
@@ -5,7 +5,7 @@ publish {
 
   description = "Telemetries published by IRIS Cold Stop Assembly."
 
-  telemetry = [
+  events = [
     {
       name = current
       description = """

--- a/imager/detector-assembly/publish-model.conf
+++ b/imager/detector-assembly/publish-model.conf
@@ -2,7 +2,7 @@ subsystem = IRIS
 component = imager-detector-assembly
 
 publish {
-    telemetry = [
+    events = [
     {
       name = state
       description = "Standard assembly state as defiend in [Technical Document: Software Design Patterns for Device and Component Controllers (TMT.INS.TEC.16.079.REL01)](https://docushare.tmt.org/docushare/dsweb/Get/Document-57492/cc_design_patterns_REL01.pdf)."
@@ -306,9 +306,6 @@ Note that the read noise may be different among pixels, channels or areas. The a
                 }
             ]
         }
-    ]
-
-    events = [
         {
             name = startExposure
             description = """

--- a/imager/filter-assembly/publish-model.conf
+++ b/imager/filter-assembly/publish-model.conf
@@ -27,9 +27,6 @@ Telemetries published by IRIS Filter Assembly.
         }
       ]
     }
-  ]
-
-  telemetry = [
     {
       name = filter
       description = "Imager filter"

--- a/imager/pupilview-assembly/publish-model.conf
+++ b/imager/pupilview-assembly/publish-model.conf
@@ -9,7 +9,7 @@ Telemetries published by IRIS Pupil Viewing Assembly.
 __TODO__: Define the telemetries of DETECTOR functional group.
 """
 
-  telemetry = [
+  events = [
     {
       name = MIRROR_state
       description = "Standard assembly state as defiend in [Technical Document: Software Design Patterns for Device and Component Controllers (TMT.INS.TEC.16.079.REL01)](https://docushare.tmt.org/docushare/dsweb/Get/Document-57492/cc_design_patterns_REL01.pdf)."


### PR DESCRIPTION
This pull request moves all telemetries of the Imager assemblies to events because CSW will no longer distinguish telemetries from events.